### PR TITLE
Eli 47 transfer link inspector settings to granite console

### DIFF
--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/resolvers/ExternalLinkResolverImpl.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/resolvers/ExternalLinkResolverImpl.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
 /**
  * Validates external links via sending HEAD requests concurrently using {@link PoolingHttpClientConnectionManager}
  */
-@Component(service = LinkResolver.class)
+@Component(service = {LinkResolver.class, ExternalLinkResolverImpl.class})
 @Designate(ocd = ExternalLinkResolverImpl.Configuration.class)
 public class ExternalLinkResolverImpl implements LinkResolver {
 

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/resolvers/InternalLinkResolverImpl.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/resolvers/InternalLinkResolverImpl.java
@@ -68,8 +68,8 @@ public class InternalLinkResolverImpl implements LinkResolver {
 
     private String internalLinksHost;
 
-    @Reference(target = "(service.pid=com.exadel.etoolbox.linkinspector.core.services.resolvers.ExternalLinkResolverImpl)")
-    private LinkResolver externalLinkResolver;
+    @Reference
+    private ExternalLinkResolverImpl externalLinkResolver;
 
     @Activate
     @Modified

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/GraniteUtil.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/GraniteUtil.java
@@ -1,0 +1,34 @@
+package com.exadel.etoolbox.linkinspector.core.services.util;
+
+import com.adobe.granite.ui.components.ds.ValueMapResource;
+import com.day.cq.commons.jcr.JcrConstants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GraniteUtil {
+    public static Resource createTab(ResourceResolver resolver, String path, String title, Collection<Resource> children) {
+
+        Resource items = createResource(resolver, path + "/items", Collections.emptyMap(), children);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JcrConstants.JCR_TITLE, title);
+        properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "granite/ui/components/coral/foundation/container");
+        return createResource(resolver, path, properties, Collections.singletonList(items));
+    }
+
+    public static Resource createResource(ResourceResolver resolver, String path, Map<String, Object> properties, Collection<Resource> children) {
+
+        ValueMap valueMap = new ValueMapDecorator(properties);
+        String resourceType = StringUtils.defaultIfEmpty(properties.getOrDefault(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, StringUtils.EMPTY).toString(), JcrConstants.NT_UNSTRUCTURED);
+        return new ValueMapResource(resolver, path, resourceType, valueMap, children);
+    }
+}

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/ServletUtil.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/ServletUtil.java
@@ -14,6 +14,8 @@
 
 package com.exadel.etoolbox.linkinspector.core.services.util;
 
+import com.adobe.granite.ui.components.ds.ValueMapResource;
+import com.day.cq.commons.jcr.JcrConstants;
 import org.apache.commons.lang.CharEncoding;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -21,14 +23,16 @@ import org.apache.http.entity.ContentType;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class ServletUtil {
@@ -67,5 +71,22 @@ public class ServletUtil {
         } catch (IOException e) {
             LOG.error("Failed to write json to response", e);
         }
+    }
+
+    public static Resource createTab(ResourceResolver resolver, String path, String title, Collection<Resource> children) {
+
+        Resource items = createResource(resolver, path + "/items", Collections.emptyMap(), children);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(JcrConstants.JCR_TITLE, title);
+        properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "granite/ui/components/coral/foundation/container");
+        return createResource(resolver, path, properties, Collections.singletonList(items));
+    }
+
+    public static Resource createResource(ResourceResolver resolver, String path, Map<String, Object> properties, Collection<Resource> children) {
+
+        ValueMap valueMap = new ValueMapDecorator(properties);
+        String resourceType = StringUtils.defaultIfEmpty(properties.getOrDefault(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, StringUtils.EMPTY).toString(), JcrConstants.NT_UNSTRUCTURED);
+        return new ValueMapResource(resolver, path, resourceType, valueMap, children);
     }
 }

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/ServletUtil.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/services/util/ServletUtil.java
@@ -14,8 +14,6 @@
 
 package com.exadel.etoolbox.linkinspector.core.services.util;
 
-import com.adobe.granite.ui.components.ds.ValueMapResource;
-import com.day.cq.commons.jcr.JcrConstants;
 import org.apache.commons.lang.CharEncoding;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -23,11 +21,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.wrappers.ValueMapDecorator;
-import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,22 +64,5 @@ public class ServletUtil {
         } catch (IOException e) {
             LOG.error("Failed to write json to response", e);
         }
-    }
-
-    public static Resource createTab(ResourceResolver resolver, String path, String title, Collection<Resource> children) {
-
-        Resource items = createResource(resolver, path + "/items", Collections.emptyMap(), children);
-
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(JcrConstants.JCR_TITLE, title);
-        properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "granite/ui/components/coral/foundation/container");
-        return createResource(resolver, path, properties, Collections.singletonList(items));
-    }
-
-    public static Resource createResource(ResourceResolver resolver, String path, Map<String, Object> properties, Collection<Resource> children) {
-
-        ValueMap valueMap = new ValueMapDecorator(properties);
-        String resourceType = StringUtils.defaultIfEmpty(properties.getOrDefault(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, StringUtils.EMPTY).toString(), JcrConstants.NT_UNSTRUCTURED);
-        return new ValueMapResource(resolver, path, resourceType, valueMap, children);
     }
 }

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/LinkTypesDataSourceServlet.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/LinkTypesDataSourceServlet.java
@@ -1,0 +1,55 @@
+package com.exadel.etoolbox.linkinspector.core.servlets;
+
+import com.adobe.granite.ui.components.ds.DataSource;
+import com.adobe.granite.ui.components.ds.SimpleDataSource;
+import com.exadel.etoolbox.linkinspector.api.LinkResolver;
+import com.exadel.etoolbox.linkinspector.core.services.util.ServletUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import javax.servlet.Servlet;
+import java.util.*;
+
+/**
+ * @author Sergey Soldatenko
+ */
+@Component(service = {Servlet.class})
+@SlingServletResourceTypes(
+        resourceTypes = "/bin/etoolbox/link-inspector/settings/linktypes",
+        methods = HttpConstants.METHOD_GET)
+public class LinkTypesDataSourceServlet extends SlingSafeMethodsServlet {
+
+    @Reference
+    private transient List<LinkResolver> linkResolvers;
+
+    @Override
+    protected void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
+
+        List<Resource> links = new ArrayList<>();
+        for (LinkResolver linkResolver : linkResolvers) {
+            Map<String, Object> fieldProperties = new HashMap<>();
+            fieldProperties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, "granite/ui/components/coral/foundation/form/checkbox");
+
+            String serviceName = linkResolver.getClass().getName();
+            fieldProperties.put("name", "./" + serviceName + ".linkType");
+            fieldProperties.put("text", StringUtils.substringAfterLast(serviceName, "."));
+            fieldProperties.put("fieldDescription", StringUtils.substringAfterLast(serviceName, "."));
+            fieldProperties.put("uncheckedValue", Boolean.FALSE);
+            fieldProperties.put("checked", Boolean.FALSE);
+            fieldProperties.put("value", Boolean.TRUE);
+            Resource checkBox = ServletUtil.createResource(request.getResourceResolver(), serviceName, fieldProperties, Collections.emptyList());
+            links.add(checkBox);
+        }
+
+        DataSource dataSource = new SimpleDataSource(links.iterator());
+        request.setAttribute(DataSource.class.getName(), dataSource);
+    }
+}

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/LinkTypesDataSourceServlet.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/LinkTypesDataSourceServlet.java
@@ -3,7 +3,7 @@ package com.exadel.etoolbox.linkinspector.core.servlets;
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.adobe.granite.ui.components.ds.SimpleDataSource;
 import com.exadel.etoolbox.linkinspector.api.LinkResolver;
-import com.exadel.etoolbox.linkinspector.core.services.util.ServletUtil;
+import com.exadel.etoolbox.linkinspector.core.services.util.GraniteUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -18,9 +18,6 @@ import org.osgi.service.component.annotations.Reference;
 import javax.servlet.Servlet;
 import java.util.*;
 
-/**
- * @author Sergey Soldatenko
- */
 @Component(service = {Servlet.class})
 @SlingServletResourceTypes(
         resourceTypes = "/bin/etoolbox/link-inspector/settings/linktypes",
@@ -45,7 +42,7 @@ public class LinkTypesDataSourceServlet extends SlingSafeMethodsServlet {
             fieldProperties.put("uncheckedValue", Boolean.FALSE);
             fieldProperties.put("checked", Boolean.FALSE);
             fieldProperties.put("value", Boolean.TRUE);
-            Resource checkBox = ServletUtil.createResource(request.getResourceResolver(), serviceName, fieldProperties, Collections.emptyList());
+            Resource checkBox = GraniteUtil.createResource(request.getResourceResolver(), serviceName, fieldProperties, Collections.emptyList());
             links.add(checkBox);
         }
 

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/SettingsDataSourceServlet.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/SettingsDataSourceServlet.java
@@ -1,13 +1,11 @@
 package com.exadel.etoolbox.linkinspector.core.servlets;
 
-/**
- * @author Sergey Soldatenko
- */
 
 import com.adobe.granite.ui.components.ds.DataSource;
 import com.adobe.granite.ui.components.ds.SimpleDataSource;
 import com.exadel.etoolbox.linkinspector.api.LinkResolver;
-import com.exadel.etoolbox.linkinspector.core.services.util.ServletUtil;
+import com.exadel.etoolbox.linkinspector.core.services.util.GraniteUtil;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -62,10 +60,10 @@ public class SettingsDataSourceServlet extends SlingSafeMethodsServlet {
                 fieldProperties.put("name", "./" + serviceName + "." + attributeDefinition.getID());
                 fieldProperties.put("fieldLabel", attributeDefinition.getName());
                 fieldProperties.put("fieldDescription", attributeDefinition.getDescription());
-                Resource textField = ServletUtil.createResource(request.getResourceResolver(), serviceName + "." + attributeDefinition.getID(), fieldProperties, Collections.emptyList());
+                Resource textField = GraniteUtil.createResource(request.getResourceResolver(), serviceName + "." + attributeDefinition.getID(), fieldProperties, Collections.emptyList());
                 innerFields.add(textField);
             }
-            Resource tab = ServletUtil.createTab(request.getResourceResolver(), serviceName, splitCamelCase(StringUtils.substringAfterLast(serviceName, ".")), innerFields);
+            Resource tab = GraniteUtil.createTab(request.getResourceResolver(), serviceName, splitCamelCase(StringUtils.substringAfterLast(serviceName, ".")), innerFields);
             tabs.add(tab);
         }
 
@@ -99,7 +97,7 @@ public class SettingsDataSourceServlet extends SlingSafeMethodsServlet {
 
     private Map<String, List<AttributeDefinition>> getServiceSettings() {
         Map<String, List<AttributeDefinition>> result = new HashMap<>();
-        for (LinkResolver linkResolver : linkResolvers) {
+        for (LinkResolver linkResolver : CollectionUtils.emptyIfNull(linkResolvers)) {
             Bundle bundle = FrameworkUtil.getBundle(linkResolver.getClass());
             MetaTypeInformation metaTypeInformation = metaTypeService.getMetaTypeInformation(bundle);
             ObjectClassDefinition objectClassDefinition = metaTypeInformation.getObjectClassDefinition(linkResolver.getClass().getName(), null);

--- a/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/SettingsDataSourceServlet.java
+++ b/core/src/main/java/com/exadel/etoolbox/linkinspector/core/servlets/SettingsDataSourceServlet.java
@@ -1,0 +1,114 @@
+package com.exadel.etoolbox.linkinspector.core.servlets;
+
+/**
+ * @author Sergey Soldatenko
+ */
+
+import com.adobe.granite.ui.components.ds.DataSource;
+import com.adobe.granite.ui.components.ds.SimpleDataSource;
+import com.exadel.etoolbox.linkinspector.api.LinkResolver;
+import com.exadel.etoolbox.linkinspector.core.services.util.ServletUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.HttpConstants;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.MetaTypeInformation;
+import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
+
+import javax.servlet.Servlet;
+import java.util.*;
+
+@Component(service = {Servlet.class})
+@SlingServletResourceTypes(
+        resourceTypes = "/bin/etoolbox/link-inspector/settings",
+        methods = HttpConstants.METHOD_GET)
+public class SettingsDataSourceServlet extends SlingSafeMethodsServlet {
+
+    @Reference
+    private transient MetaTypeService metaTypeService;
+
+    @Reference
+    private transient List<LinkResolver> linkResolvers;
+
+    @Override
+    protected void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
+
+        String rootPath = request.getRequestPathInfo().getResourcePath();
+        Resource mainTab = request.getResourceResolver().getResource(rootPath + "/main");
+        Resource advancedTab = request.getResourceResolver().getResource(rootPath + "/advanced");
+
+        List<Resource> tabs = new ArrayList<>();
+        tabs.add(mainTab);
+        tabs.add(advancedTab);
+
+        Map<String, List<AttributeDefinition>> serviceSettings = getServiceSettings();
+        for (Map.Entry<String, List<AttributeDefinition>> stringListEntry : serviceSettings.entrySet()) {
+            String serviceName = stringListEntry.getKey();
+            List<Resource> innerFields = new ArrayList<>();
+            for (AttributeDefinition attributeDefinition : stringListEntry.getValue()) {
+                Map<String, Object> fieldProperties = new HashMap<>();
+                fieldProperties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, getResourceTypeByType(attributeDefinition.getType()));
+
+                fieldProperties.put("name", "./" + serviceName + "." + attributeDefinition.getID());
+                fieldProperties.put("fieldLabel", attributeDefinition.getName());
+                fieldProperties.put("fieldDescription", attributeDefinition.getDescription());
+                Resource textField = ServletUtil.createResource(request.getResourceResolver(), serviceName + "." + attributeDefinition.getID(), fieldProperties, Collections.emptyList());
+                innerFields.add(textField);
+            }
+            Resource tab = ServletUtil.createTab(request.getResourceResolver(), serviceName, splitCamelCase(StringUtils.substringAfterLast(serviceName, ".")), innerFields);
+            tabs.add(tab);
+        }
+
+        DataSource dataSource = new SimpleDataSource(tabs.iterator());
+        request.setAttribute(DataSource.class.getName(), dataSource);
+    }
+
+    private String splitCamelCase(String s) {
+        return s.replaceAll(
+                String.format("%s|%s|%s",
+                        "(?<=[A-Z])(?=[A-Z][a-z])",
+                        "(?<=[^A-Z])(?=[A-Z])",
+                        "(?<=[A-Za-z])(?=[^A-Za-z])"
+                ),
+                " "
+        );
+    }
+
+    private String getResourceTypeByType(int type) {
+        String result;
+        switch (type) {
+            case 3:
+                result = "granite/ui/components/coral/foundation/form/numberfield";
+                break;
+            default:
+                result = "granite/ui/components/coral/foundation/form/textfield";
+                break;
+        }
+        return result;
+    }
+
+    private Map<String, List<AttributeDefinition>> getServiceSettings() {
+        Map<String, List<AttributeDefinition>> result = new HashMap<>();
+        for (LinkResolver linkResolver : linkResolvers) {
+            Bundle bundle = FrameworkUtil.getBundle(linkResolver.getClass());
+            MetaTypeInformation metaTypeInformation = metaTypeService.getMetaTypeInformation(bundle);
+            ObjectClassDefinition objectClassDefinition = metaTypeInformation.getObjectClassDefinition(linkResolver.getClass().getName(), null);
+            AttributeDefinition[] definitions = objectClassDefinition.getAttributeDefinitions(ObjectClassDefinition.ALL);
+
+            result.put(linkResolver.getClass().getName(), Arrays.asList(definitions));
+        }
+        return result;
+    }
+
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/clientlibs/link-inspector-ui/css/console-ui.less
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/clientlibs/link-inspector-ui/css/console-ui.less
@@ -159,3 +159,8 @@ tr.elc-card {
   }
 }
 
+.options-page{
+    min-width: 40rem ;
+    width: 50% ;
+}
+

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
@@ -171,15 +171,6 @@
                                                         uncheckedValue="{Boolean}false"
                                                         checked="{Boolean}false"
                                                         value="{Boolean}true"/>
-                                                <excludeTags
-                                                        jcr:primaryType="nt:unstructured"
-                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                        name="./excludeTags"
-                                                        text="Exclude tags"
-                                                        fieldDescription="If checked, the internal links starting with /content/cq:tags will be excluded"
-                                                        uncheckedValue="{Boolean}false"
-                                                        checked="{Boolean}false"
-                                                        value="{Boolean}true"/>
                                                 <statusCodes
                                                         granite:class="foundation-layout-util-maximized-alt"
                                                         jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:granite="http://www.adobe.com/jcr/granite/1.0"
+          xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="sling:Folder">
+    <options jcr:primaryType="cq:Page">
+        <jcr:content jcr:primaryType="nt:unstructured"
+                     jcr:title="Link Inspector options"
+                     sling:resourceType="granite/ui/components/shell/page">
+            <head jcr:primaryType="nt:unstructured">
+                <clientlibs
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
+                        categories="[coralui3,granite.ui.coral.foundation]"/>
+            </head>
+            <title jcr:primaryType="nt:unstructured"
+                   sling:resourceType="granite/ui/components/coral/foundation/text"
+                   text="Link Inspector options"/>
+            <actions jcr:primaryType="nt:unstructured">
+                <secondary jcr:primaryType="nt:unstructured">
+                    <!--<cancel
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
+                            text="Cancel"
+                            granite:class="elc-options-cancel-button"
+                            x-cq-linkchecker="skip"/>
+                    <apply
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
+                            text="Apply"
+                            variant="primary"
+                            granite:class="elc-options-apply-button"
+                            x-cq-linkchecker="skip"/>-->
+                </secondary>
+            </actions>
+            <content jcr:primaryType="nt:unstructured"
+                     sling:resourceType="granite/ui/components/coral/foundation/container">
+                <items jcr:primaryType="nt:unstructured">
+                    <columns jcr:primaryType="nt:unstructured"
+                             sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+
+                             maximized="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <form jcr:primaryType="nt:unstructured"
+                                  sling:resourceType="granite/ui/components/coral/foundation/form"
+                                  method="post"
+                                  dataPath="/conf/etoolbox-link-inspector/data/optionsconfig"
+                                  action="/conf/etoolbox-link-inspector/data/optionsconfig"
+                                  style="vertical">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <tabs jcr:primaryType="nt:unstructured"
+                                          maximized="{Boolean}true"
+                                          size="L"
+                                          sling:resourceType="granite/ui/components/coral/foundation/tabs">
+                                        <main jcr:primaryType="nt:unstructured"
+                                              sling:resourceType="granite/ui/components/coral/foundation/container"
+                                              jcr:title="Main Config"
+                                              maximized="{Boolean}true">
+                                            <items jcr:primaryType="nt:unstructured">
+                                                <replacement
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                        fieldLabel="Path"
+                                                        fieldDescription="The content path for searching broken links. The search path should be located under /content"
+                                                        required="{Boolean}true"
+                                                        name="./replacement"
+                                                        rootPath="/content"/>
+                                                <excludedPaths
+                                                        granite:class="foundation-layout-util-maximized-alt"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                        composite="{Boolean}true"
+                                                        name="./excludedPaths"
+                                                        fieldLabel="Excluded Paths"
+                                                        fieldDescription="The list of paths excluded from processing. The specified path and all its children are excluded. The excluded path should not end with slash. Can be specified as a regex"
+                                                        renderReadOnly="{Boolean}true">
+                                                    <field
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/pathfield"
+                                                            rootPath="/content"
+                                                            name="./excludedPaths">
+                                                    </field>
+                                                </excludedPaths>
+                                                <activatedContent
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./activatedContent"
+                                                        text="Activated Content"
+                                                        fieldDescription="If checked, links will be retrieved from activated content only"
+                                                        uncheckedValue="{Boolean}false"
+                                                        checked="{Boolean}false"
+                                                        value="{Boolean}true"/>
+                                                <skipContentAfterActivation
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./skipContentAfterActivation"
+                                                        text="Skip non-published content and content changed after publishing"
+                                                        fieldDescription="Works in conjunction with the 'Activated Content' checkbox only. If checked, links will be retrieved from activated content that is not modified after activation (lastModified is before lastReplicated)"
+                                                        uncheckedValue="{Boolean}false"
+                                                        checked="{Boolean}false"
+                                                        value="{Boolean}true"/>
+                                                <excludedLinkPatterns
+                                                        granite:class="foundation-layout-util-maximized-alt"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                        composite="{Boolean}true"
+                                                        name="./excludedLinkPatterns"
+                                                        fieldLabel="Excluded links patterns"
+                                                        fieldDescription="Links are excluded from processing if they match any of the specified regex patterns"
+                                                        renderReadOnly="{Boolean}true">
+                                                    <field
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            name="./excludedLinkPatterns">
+                                                    </field>
+                                                </excludedLinkPatterns>
+                                                <lastMidified
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/datepicker"
+                                                        fieldLabel="Last Modified"
+                                                        fieldDescription="The content modified before the specified date will be excluded. Tha date should has the ISO-like date-time format, such as '2011-12-03T10:15:30+01:00')"
+                                                        name="./lastMidified"/>
+                                                <excludedProperties
+                                                        granite:class="foundation-layout-util-maximized-alt"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                        composite="{Boolean}true"
+                                                        name="./excludedProperties"
+                                                        fieldLabel="Excluded Properties"
+                                                        fieldDescription="The list of properties excluded from processing. Each value can be specified as a regex"
+                                                        renderReadOnly="{Boolean}true">
+                                                    <field
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                            name="./excludedProperties">
+                                                    </field>
+                                                </excludedProperties>
+
+                                                <linkTypes
+                                                        jcr:primaryType="nt:unstructured"
+                                                        jcr:title="Links type (The type of links in the report)"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+
+                                                        <datasource jcr:primaryType="nt:unstructured"
+                                                                    sling:resourceType="/bin/etoolbox/link-inspector/settings/linktypes"/>
+
+                                                </linkTypes>
+
+                                            </items>
+                                        </main>
+                                        <advanced jcr:primaryType="nt:unstructured"
+                                                  sling:resourceType="granite/ui/components/coral/foundation/container"
+                                                  jcr:title="Advanced Config"
+                                                  margin="{Boolean}true"
+                                                  maximized="{Boolean}true">
+                                            <items jcr:primaryType="nt:unstructured"
+                                                   sling:resourceType="granite/ui/components/coral/foundation/container">
+                                                <text jcr:primaryType="nt:unstructured"
+                                                      sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                      fieldLabel="Advanced Tab - Text"
+                                                      name="./advancedText">
+                                                </text>
+                                            </items>
+                                        </advanced>
+                                        <datasource jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="/bin/etoolbox/link-inspector/settings"/>
+                                    </tabs>
+                                    <save
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/button"
+                                            type="submit"
+                                            granite:id="elc-options-savesettings"
+                                            granite:title="Save settings"
+                                            icon="save"
+                                            text="Save settings"/>
+                                </items>
+                            </form>
+                        </items>
+                    </columns>
+                </items>
+            </content>
+        </jcr:content>
+
+    </options>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/.content.xml
@@ -26,26 +26,21 @@
                 <clientlibs
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="granite/ui/components/coral/foundation/includeclientlibs"
-                        categories="[coralui3,granite.ui.coral.foundation]"/>
+                        categories="[coralui3,granite.ui.coral.foundation,link-inspector-ui]"/>
             </head>
             <title jcr:primaryType="nt:unstructured"
                    sling:resourceType="granite/ui/components/coral/foundation/text"
                    text="Link Inspector options"/>
             <actions jcr:primaryType="nt:unstructured">
                 <secondary jcr:primaryType="nt:unstructured">
-                    <!--<cancel
+                    <save
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                            text="Cancel"
-                            granite:class="elc-options-cancel-button"
-                            x-cq-linkchecker="skip"/>
-                    <apply
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                            text="Apply"
-                            variant="primary"
-                            granite:class="elc-options-apply-button"
-                            x-cq-linkchecker="skip"/>-->
+                            sling:resourceType="granite/ui/components/coral/foundation/button"
+                            type="submit"
+                            formId="elc-options-savesettings"
+                            granite:title="Save settings"
+                            icon="save"
+                            text="Save settings"/>
                 </secondary>
             </actions>
             <content jcr:primaryType="nt:unstructured"
@@ -57,11 +52,18 @@
                              maximized="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
                             <form jcr:primaryType="nt:unstructured"
+                                  granite:class="options-page"
                                   sling:resourceType="granite/ui/components/coral/foundation/form"
+                                  granite:id="elc-options-savesettings"
                                   method="post"
+                                  foundationForm="true"
                                   dataPath="/conf/etoolbox-link-inspector/data/optionsconfig"
                                   action="/conf/etoolbox-link-inspector/data/optionsconfig"
                                   style="vertical">
+                                <successresponse
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Settings saved"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/responses/reload"/>
                                 <items jcr:primaryType="nt:unstructured">
                                     <tabs jcr:primaryType="nt:unstructured"
                                           maximized="{Boolean}true"
@@ -160,6 +162,39 @@
                                                                     sling:resourceType="/bin/etoolbox/link-inspector/settings/linktypes"/>
 
                                                 </linkTypes>
+                                                <allowCustomLinkTypes
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./customTypeAllowed"
+                                                        text="Allow custom link type"
+                                                        fieldDescription="If checked custom link types will be included in the reports"
+                                                        uncheckedValue="{Boolean}false"
+                                                        checked="{Boolean}false"
+                                                        value="{Boolean}true"/>
+                                                <excludeTags
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                        name="./excludeTags"
+                                                        text="Exclude tags"
+                                                        fieldDescription="If checked, the internal links starting with /content/cq:tags will be excluded"
+                                                        uncheckedValue="{Boolean}false"
+                                                        checked="{Boolean}false"
+                                                        value="{Boolean}true"/>
+                                                <statusCodes
+                                                        granite:class="foundation-layout-util-maximized-alt"
+                                                        jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/coral/foundation/form/multifield"
+                                                        composite="{Boolean}true"
+                                                        name="./statusCodes"
+                                                        fieldLabel="Status codes"
+                                                        fieldDescription="The list of status codes allowed for broken links in the report. Set a single negative value to allow all http error codes"
+                                                        renderReadOnly="{Boolean}true">
+                                                    <field
+                                                            jcr:primaryType="nt:unstructured"
+                                                            sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                            name="./statusCodes">
+                                                    </field>
+                                                </statusCodes>
 
                                             </items>
                                         </main>
@@ -171,23 +206,17 @@
                                             <items jcr:primaryType="nt:unstructured"
                                                    sling:resourceType="granite/ui/components/coral/foundation/container">
                                                 <text jcr:primaryType="nt:unstructured"
-                                                      sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                                      fieldLabel="Advanced Tab - Text"
-                                                      name="./advancedText">
+                                                      sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                      fieldLabel="Threads per core"
+                                                      fieldDescription="The number of threads created per each CPU core for validating links in parallel"
+                                                      defaultValuestring="60"
+                                                      name="./threadsPerCore">
                                                 </text>
                                             </items>
                                         </advanced>
                                         <datasource jcr:primaryType="nt:unstructured"
                                                     sling:resourceType="/bin/etoolbox/link-inspector/settings"/>
                                     </tabs>
-                                    <save
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/button"
-                                            type="submit"
-                                            granite:id="elc-options-savesettings"
-                                            granite:title="Save settings"
-                                            icon="save"
-                                            text="Save settings"/>
                                 </items>
                             </form>
                         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/_rep_policy.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/etoolbox-link-inspector/options/_rep_policy.xml
@@ -12,10 +12,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<workspaceFilter version="1.0">
-    <filter root="/apps/etoolbox-link-inspector/clientlibs"/>
-    <filter root="/apps/etoolbox-link-inspector/components"/>
-    <filter root="/apps/etoolbox-link-inspector/options"/>
-    <filter root="/apps/etoolbox-link-inspector/nav"/>
-    <filter root="/apps/cq/core/content/nav/tools/etoolbox/link-inspector" mode="update"/>
-</workspaceFilter>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+          jcr:primaryType="rep:ACL">
+    <allow
+            jcr:primaryType="rep:GrantACE"
+            rep:principalName="everyone"
+            rep:privileges="{Name}[jcr:read]"/>
+</jcr:root>


### PR DESCRIPTION
#52 
#47 - implemented page with configs (load & save working automatically). available on /apps/etoolbox-link-
inspector/options/options.html.  Needed implementation of internal integration with Link Inspector logic.
#37
#35
