### PR TITLE
[Tech] rewrite content filters in order to simplify project updates

### DIFF
--- a/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -13,10 +13,14 @@
   ~ limitations under the License.
   -->
 <workspaceFilter version="1.0">
-    <filter root="/home/users/system/etoolbox" mode="merge"/>
-    <filter root="/content/rep:policy" mode="merge"/>
-    <filter root="/content/etoolbox-link-inspector/link-inspector" mode="replace"/>
-    <filter root="/content/etoolbox-link-inspector" mode="merge"/>
-    <filter root="/conf/etoolbox-link-inspector" mode="merge"/>
-    <filter root="/conf/etoolbox/link-inspector" mode="merge"/>
+    <filter root="/home/users/system/etoolbox/YhFMjFNu-eqtti9pXW7O"/>
+    <filter root="/content/rep:policy"/>
+    <filter root="/content/etoolbox-link-inspector/data/rep:policy"/>
+    <filter root="/content/etoolbox-link-inspector/download/rep:policy"/>
+    <filter root="/content/etoolbox-link-inspector">
+        <exclude pattern="/content/etoolbox-link-inspector/data(/.*)?"/>
+        <exclude pattern="/content/etoolbox-link-inspector/download(/.*)?"/>
+    </filter>
+    <filter root="/conf/etoolbox/link-inspector/rep:policy"/>
+    <filter root="/conf/etoolbox-link-inspector"/> <!-- Removes the obsolete path -->
 </workspaceFilter>


### PR DESCRIPTION
Removed "merge" mode from filters in order to simplify content updates
Please check carefully cause I am not familiar with this project and may have misunderstood how the configurations and client-generated data are stored in AEM